### PR TITLE
GLOBAL Deadzone rework

### DIFF
--- a/FranticFour/Assets/00_Scenes/PlayerSelection.unity
+++ b/FranticFour/Assets/00_Scenes/PlayerSelection.unity
@@ -361,6 +361,7 @@ MonoBehaviour:
   myPlayer: {fileID: 0}
   action1: 
   aButton: 
+  bButton: 
   playerHandler: {fileID: 0}
 --- !u!1 &545568813
 GameObject:
@@ -493,6 +494,7 @@ MonoBehaviour:
   myPlayer: {fileID: 0}
   action1: 
   aButton: 
+  bButton: 
   playerHandler: {fileID: 0}
 --- !u!1 &1015626623
 GameObject:
@@ -542,6 +544,7 @@ MonoBehaviour:
   myPlayer: {fileID: 0}
   action1: 
   aButton: 
+  bButton: 
   playerHandler: {fileID: 0}
 --- !u!1001 &1080114173
 PrefabInstance:
@@ -701,6 +704,7 @@ MonoBehaviour:
   myPlayer: {fileID: 0}
   action1: 
   aButton: 
+  bButton: 
   playerHandler: {fileID: 0}
 --- !u!1001 &1138898312
 PrefabInstance:
@@ -1140,6 +1144,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characters:
+  - {fileID: 21300000, guid: e94caa584a1c4eb419b07edb59acac1e, type: 3}
+  - {fileID: 21300000, guid: 9be433a10d16df74c9100a9551a8264e, type: 3}
+  - {fileID: 21300000, guid: f945e4e505f86a747b9ce70024b9fca9, type: 3}
+  - {fileID: 21300000, guid: 29a21d24326c3e845ba69769f11c0fe4, type: 3}
+  charactersNotSelected:
   - {fileID: 21300000, guid: e94caa584a1c4eb419b07edb59acac1e, type: 3}
   - {fileID: 21300000, guid: 9be433a10d16df74c9100a9551a8264e, type: 3}
   - {fileID: 21300000, guid: f945e4e505f86a747b9ce70024b9fca9, type: 3}

--- a/FranticFour/Assets/00_Scenes/PlayerSelection.unity
+++ b/FranticFour/Assets/00_Scenes/PlayerSelection.unity
@@ -360,6 +360,7 @@ MonoBehaviour:
   hasControllerJoined: 0
   myPlayer: {fileID: 0}
   action1: 
+  aButton: 
   playerHandler: {fileID: 0}
 --- !u!1 &545568813
 GameObject:
@@ -491,6 +492,7 @@ MonoBehaviour:
   hasControllerJoined: 0
   myPlayer: {fileID: 0}
   action1: 
+  aButton: 
   playerHandler: {fileID: 0}
 --- !u!1 &1015626623
 GameObject:
@@ -539,6 +541,7 @@ MonoBehaviour:
   hasControllerJoined: 0
   myPlayer: {fileID: 0}
   action1: 
+  aButton: 
   playerHandler: {fileID: 0}
 --- !u!1001 &1080114173
 PrefabInstance:
@@ -697,6 +700,7 @@ MonoBehaviour:
   hasControllerJoined: 0
   myPlayer: {fileID: 0}
   action1: 
+  aButton: 
   playerHandler: {fileID: 0}
 --- !u!1001 &1138898312
 PrefabInstance:

--- a/FranticFour/Assets/01_Scripts/Managers/DeadZones.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/DeadZones.cs
@@ -1,0 +1,18 @@
+﻿public static class DeadZones
+{
+    //Left controller stick
+    public const float DEADZONE_LEFT_X = 0.3f;
+    public const float DEADZONE_LEFT_Y = 0.3f;
+    /// <summary>
+    /// Should be used to check input from "Horizontal" or "Vertical".
+    /// </summary>
+    public const float DEADZONE_LEFT = 0.3f;
+        
+    //right controller stick
+    public const float DEADZONE_RIGHT_X = 0.3f;
+    public const float DEADZONE_RIGHT_Y = 0.3f;
+    /// <summary>
+    /// Should be used to check input from "RightHorizontal" or "RightVertical".
+    /// </summary>
+    public const float DEADZONE_RIGHT = 0.3f;
+}

--- a/FranticFour/Assets/01_Scripts/Managers/DeadZones.cs.meta
+++ b/FranticFour/Assets/01_Scripts/Managers/DeadZones.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 600795cd8bdc6b140b890e7105fe8135
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
@@ -27,4 +27,10 @@
         public const string Jump = "Jump"; //R1 | XBOX, PS4
         public const string JumpKeboard = "JumpKeyboard"; //Keyboard
     }
+
+    public struct ButtonInputs
+    {
+        public const string A_Button = "ButtonA"; //XBOX
+        public const string X_ButtonPS4 = "ButtonXPS4"; //PS4
+    }
 }

--- a/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
@@ -33,5 +33,9 @@
         public const string A_Button = "ButtonA"; //XBOX
         public const string X_ButtonPS4 = "ButtonXPS4"; //PS4
         public const string A_ButtonKeyboard = "JumpKeyboard"; //Keyboard
+
+        public const string B_Button = "ButtonB"; //XBOX
+        public const string Circle_ButtonPS4 = "ButtonCirclePS4"; //PS4
+        public const string B_ButtonKeyboard = "ButtonBKeyboard"; //Keyboard
     }
 }

--- a/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
@@ -32,5 +32,6 @@
     {
         public const string A_Button = "ButtonA"; //XBOX
         public const string X_ButtonPS4 = "ButtonXPS4"; //PS4
+        public const string A_ButtonKeyboard = "JumpKeyboard"; //Keyboard
     }
 }

--- a/FranticFour/Assets/01_Scripts/Player/MovementController.cs
+++ b/FranticFour/Assets/01_Scripts/Player/MovementController.cs
@@ -51,7 +51,13 @@ public class MovementController : MonoBehaviour
     {
         float xMovement = Input.GetAxis(controller.Horizontal);
         float yMovement = Input.GetAxis(controller.Vertical);
-        return new Vector2(xMovement, yMovement);
+        
+        Vector2 m_tempVec = new Vector2(xMovement, yMovement);
+        
+        if(m_tempVec.magnitude < DeadZones.DEADZONE_LEFT)
+            m_tempVec = Vector2.zero;
+
+        return m_tempVec;
     }
 
     public void ResetMovement()

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/CharacterMaskClose.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/CharacterMaskClose.cs
@@ -1,13 +1,19 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 
 public class CharacterMaskClose : MonoBehaviour
 {
     [SerializeField] private float animTime = 1.2f;
+    [SerializeField] private float animTimeDeselect = 0.5f;
     [SerializeField] private float xScaleTo = 3f;
+    [SerializeField] private float xStandard = 6f;
 
     public void OnSelected()
     {
         LeanTween.scaleX(gameObject, xScaleTo, animTime);
+    }
+    
+    public void OnDeselected()
+    {
+        LeanTween.scaleX(gameObject, xStandard, animTimeDeselect);
     }
 }

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/CharacterMaskClose.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/CharacterMaskClose.cs
@@ -6,14 +6,45 @@ public class CharacterMaskClose : MonoBehaviour
     [SerializeField] private float animTimeDeselect = 0.5f;
     [SerializeField] private float xScaleTo = 3f;
     [SerializeField] private float xStandard = 6f;
+    private int activeLeanTweenID = 0;
 
     public void OnSelected()
     {
-        LeanTween.scaleX(gameObject, xScaleTo, animTime);
+        float m_ScTS = Mathf.Abs(xScaleTo - xStandard);
+        float m_ScC = Mathf.Abs(transform.localScale.x - xScaleTo);
+        
+        float m_time = (animTime / m_ScTS) * m_ScC;
+        
+        LeanTween.cancel(activeLeanTweenID);
+        activeLeanTweenID = LeanTween.scaleX(gameObject, xScaleTo, m_time).setOnComplete(ScaledUp).id;
     }
     
     public void OnDeselected()
     {
-        LeanTween.scaleX(gameObject, xStandard, animTimeDeselect);
+        float m_ScTS = Mathf.Abs(xScaleTo - xStandard);
+        float m_ScC = Mathf.Abs(transform.localScale.x - xStandard);
+        
+        float m_time = (animTimeDeselect / m_ScTS) * m_ScC;
+        
+        
+        LeanTween.cancel(activeLeanTweenID);
+        activeLeanTweenID = LeanTween.scaleX(gameObject, xStandard, m_time).setOnComplete(ScaledStandard).id;
+    }
+
+    private void ScaledUp()
+    {
+        Vector3 m_scale = new Vector3();
+
+        m_scale.x = xScaleTo;
+        m_scale.y = transform.localScale.y;
+        m_scale.z = transform.localScale.z;
+    }
+    private void ScaledStandard()
+    {
+        Vector3 m_scale = new Vector3();
+
+        m_scale.x = xStandard;
+        m_scale.y = transform.localScale.y;
+        m_scale.z = transform.localScale.z;
     }
 }

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/CharacterSelection.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/CharacterSelection.cs
@@ -44,6 +44,14 @@ public class CharacterSelection : MonoBehaviour
         playersSpriteHandler.OnSpriteChange.RemoveListener(UpdateSprites);
         playersSpriteHandler.SetSelected(selectedCharacterIndex);
     }
+    
+    public void CharacterDeselected()
+    {
+        // 1 = the renderer in the middle
+        spriteRenderers[1].sprite = playersSpriteHandler.GetDeselected(selectedCharacterIndex);
+        playersSpriteHandler.OnSpriteChange.AddListener(UpdateSprites);
+        playersSpriteHandler.SetDeselected(selectedCharacterIndex);
+    }
 
     public void NextCharacter(bool _right)
     {

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/InputManager.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/InputManager.cs
@@ -37,6 +37,11 @@ public class InputManager : MonoBehaviour
         playersSelected[_controllerID] = true;
         CheckPlayers();
     }
+    
+    public void DeselectPlayer(int _controllerID)
+    {
+        playersSelected[_controllerID] = false;
+    }
 
     public MyPlayer GetPlayer(int _controllerID)
     {

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -50,11 +50,9 @@ public class SelectionController : MonoBehaviour
 
     private void Update()
     {
-        Debug.Log(Input.GetButton(aButton));
-        
-        if (!hasControllerJoined && Input.GetAxis(action1) >= 1 - deadZoneAction) //For PS4, Xbox and Keyboard
+        if (!hasControllerJoined && (Input.GetAxis(action1) >= 1 - deadZoneAction || Input.GetButtonUp(aButton))) //For PS4, Xbox and Keyboard
             ControllerJoin();
-        else if (hasControllerJoined && !isSelecting && Input.GetAxis(action1) >= 1 - deadZoneAction) //For PS4, Xbox and Keyboard
+        else if (hasControllerJoined && !isSelecting && (Input.GetAxis(action1) >= 1 - deadZoneAction || Input.GetButtonUp(aButton))) //For PS4, Xbox and Keyboard
             ControllerSelectPlayer();
         else if (isSelecting && Input.GetAxis(action1) <= 0)
             isSelecting = false;
@@ -159,6 +157,7 @@ public class SelectionController : MonoBehaviour
         rightHorizontal = StringManager.Inputs.HorizontalKeyboard;
         horizontal = StringManager.Inputs.HorizontalKeyboard;
         action1 = StringManager.Inputs.Action1Keyboard;
+        aButton = StringManager.ButtonInputs.A_ButtonKeyboard;
     }
     
     private void CheckSelection(float _inputXRight, float _inputXLeft)

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class SelectionController : MonoBehaviour
 {
@@ -8,16 +9,20 @@ public class SelectionController : MonoBehaviour
     [SerializeField] private MyPlayer myPlayer;
 
     [Header("Assigned controls")]
-    [SerializeField] private string action1;
-    [SerializeField] private string aButton;
+    [SerializeField] private string action1; //Debug
+    [SerializeField] private string aButton; //Debug
+    [SerializeField] private string bButton; //Debug
     [SerializeField] private InputManager playerHandler;
 
+    //Dead-zones
     private float deadZoneX = 0f;
     private readonly float deadZoneAction = 0.5f;
     private readonly float deadZoneRight = 0.04f;
     private readonly float deadZoneLeft = 0.65f;
+    //Axis
     private string rightHorizontal = null;
     private string horizontal = null;
+    
     private bool inputBool = false;
     private bool isSelecting = false;
     private bool playerSelected = false;
@@ -50,6 +55,7 @@ public class SelectionController : MonoBehaviour
 
     private void Update()
     {
+        Debug.Log(Input.GetButton(bButton) + "ID: " + CONTROLLER_ID);
         if (!hasControllerJoined && (Input.GetAxis(action1) >= 1 - deadZoneAction || Input.GetButtonUp(aButton))) //For PS4, Xbox and Keyboard
             ControllerJoin();
         else if (hasControllerJoined && !isSelecting && (Input.GetAxis(action1) >= 1 - deadZoneAction || Input.GetButtonUp(aButton))) //For PS4, Xbox and Keyboard
@@ -130,16 +136,24 @@ public class SelectionController : MonoBehaviour
 
     private void MapXbox()
     {
+        //Buttons Xbox
         action1 = StringManager.Inputs.Action1 + CONTROLLER_ID;
         aButton = StringManager.ButtonInputs.A_Button + CONTROLLER_ID;
+        bButton = StringManager.ButtonInputs.B_Button + CONTROLLER_ID;
+        
+        //Axis Xbox
         rightHorizontal = StringManager.Inputs.RightHorizontal + CONTROLLER_ID;
         horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
     }
 
     private void MapPs4()
     {
+        //Buttons PS4
         action1 = StringManager.Inputs.Action1PS4 + CONTROLLER_ID;
         aButton = StringManager.ButtonInputs.X_ButtonPS4 + CONTROLLER_ID;
+        bButton = StringManager.ButtonInputs.Circle_ButtonPS4 + CONTROLLER_ID;
+        
+        //Axis PS4
         rightHorizontal = StringManager.Inputs.RightHorizontalPS4 + CONTROLLER_ID;
         horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
     }
@@ -151,13 +165,16 @@ public class SelectionController : MonoBehaviour
 
     private void MapKeyboard()
     {
+        //Keyboard
         PassControllersToGame.isKeyboardUsed = true;
         PassControllersToGame.keyBoardOwnedBy = CONTROLLER_ID;
                 
         rightHorizontal = StringManager.Inputs.HorizontalKeyboard;
         horizontal = StringManager.Inputs.HorizontalKeyboard;
+        
         action1 = StringManager.Inputs.Action1Keyboard;
         aButton = StringManager.ButtonInputs.A_ButtonKeyboard;
+        bButton = StringManager.ButtonInputs.B_ButtonKeyboard;
     }
     
     private void CheckSelection(float _inputXRight, float _inputXLeft)

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -63,6 +63,9 @@ public class SelectionController : MonoBehaviour
         else if (isSelecting && Input.GetAxis(action1) <= 0)
             isSelecting = false;
 
+        if (playerSelected && Input.GetButtonUp(bButton))
+            DeselectPlayer();
+
         float m_inputX = Input.GetAxis(rightHorizontal);
         float m_inputX2 = Input.GetAxis(horizontal);
         
@@ -97,6 +100,21 @@ public class SelectionController : MonoBehaviour
         myPlayer.SelectedCharacterSelection.CharacterSelected();
         
         playerHandler.SelectPlayer(CONTROLLER_ID);
+    }
+
+    private void DeselectPlayer()
+    {
+        playerSelected = false;
+        myPlayer.SelectedHighlightLerp.isLerping = true;
+        myPlayer.SelectedHighlightLerp.hasSelected = false;
+        
+        myPlayer.CharacterMaskCloseSelect.OnDeselected();
+        playerHandler.playersSelected[CONTROLLER_ID] = false;
+        
+        PassControllersToGame.playerOwnedBy[myPlayer.SelectedCharacterSelection.SelectedCharacterIndex] = 99;
+        myPlayer.SelectedCharacterSelection.CharacterDeselected();
+        
+        playerHandler.DeselectPlayer(CONTROLLER_ID);
     }
     
     private void MapController()

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -12,8 +12,9 @@ public class SelectionController : MonoBehaviour
     [SerializeField] private InputManager playerHandler;
 
     private float deadZoneX = 0f;
+    private readonly float deadZoneAction = 0.5f;
     private readonly float deadZoneRight = 0.04f;
-    private float deadZoneLeft = 0.4f;
+    private readonly float deadZoneLeft = 0.65f;
     private string rightHorizontal = null;
     private string horizontal = null;
     private bool inputBool = false;
@@ -48,9 +49,9 @@ public class SelectionController : MonoBehaviour
 
     private void Update()
     {
-        if (!hasControllerJoined && Input.GetAxis(action1) >= 1 - 0.5f) //For PS4, Xbox and Keyboard
+        if (!hasControllerJoined && Input.GetAxis(action1) >= 1 - deadZoneAction) //For PS4, Xbox and Keyboard
             ControllerJoin();
-        else if (hasControllerJoined && !isSelecting && Input.GetAxis(action1) >= 1 - 0.5f) //For PS4, Xbox and Keyboard
+        else if (hasControllerJoined && !isSelecting && Input.GetAxis(action1) >= 1 - deadZoneAction) //For PS4, Xbox and Keyboard
             ControllerSelectPlayer();
         else if (isSelecting && Input.GetAxis(action1) <= 0)
             isSelecting = false;
@@ -158,7 +159,7 @@ public class SelectionController : MonoBehaviour
     
     private void CheckSelection(float _inputXRight, float _inputXLeft)
     {
-        if (Mathf.Abs(_inputXLeft) > Mathf.Abs(_inputXRight))
+        if (Mathf.Abs(_inputXLeft) > Mathf.Abs(_inputXRight) && Mathf.Abs(_inputXLeft) > deadZoneLeft)
         {
             _inputXRight = _inputXLeft;
             deadZoneX = deadZoneLeft;

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -55,7 +55,6 @@ public class SelectionController : MonoBehaviour
 
     private void Update()
     {
-        Debug.Log(Input.GetButton(bButton) + "ID: " + CONTROLLER_ID);
         if (!hasControllerJoined && (Input.GetAxis(action1) >= 1 - deadZoneAction || Input.GetButtonUp(aButton))) //For PS4, Xbox and Keyboard
             ControllerJoin();
         else if (hasControllerJoined && !isSelecting && (Input.GetAxis(action1) >= 1 - deadZoneAction || Input.GetButtonUp(aButton))) //For PS4, Xbox and Keyboard

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -9,6 +9,7 @@ public class SelectionController : MonoBehaviour
 
     [Header("Assigned controls")]
     [SerializeField] private string action1;
+    [SerializeField] private string aButton;
     [SerializeField] private InputManager playerHandler;
 
     private float deadZoneX = 0f;
@@ -49,6 +50,8 @@ public class SelectionController : MonoBehaviour
 
     private void Update()
     {
+        Debug.Log(Input.GetButton(aButton));
+        
         if (!hasControllerJoined && Input.GetAxis(action1) >= 1 - deadZoneAction) //For PS4, Xbox and Keyboard
             ControllerJoin();
         else if (hasControllerJoined && !isSelecting && Input.GetAxis(action1) >= 1 - deadZoneAction) //For PS4, Xbox and Keyboard
@@ -61,7 +64,6 @@ public class SelectionController : MonoBehaviour
         
         if (hasControllerJoined && !playerSelected && (m_inputX != 0 || m_inputX2 != 0))
             CheckSelection(m_inputX, m_inputX2);
-
     }
 
     private void ControllerJoin()
@@ -131,6 +133,7 @@ public class SelectionController : MonoBehaviour
     private void MapXbox()
     {
         action1 = StringManager.Inputs.Action1 + CONTROLLER_ID;
+        aButton = StringManager.ButtonInputs.A_Button + CONTROLLER_ID;
         rightHorizontal = StringManager.Inputs.RightHorizontal + CONTROLLER_ID;
         horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
     }
@@ -138,6 +141,7 @@ public class SelectionController : MonoBehaviour
     private void MapPs4()
     {
         action1 = StringManager.Inputs.Action1PS4 + CONTROLLER_ID;
+        aButton = StringManager.ButtonInputs.X_ButtonPS4 + CONTROLLER_ID;
         rightHorizontal = StringManager.Inputs.RightHorizontalPS4 + CONTROLLER_ID;
         horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
     }

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -11,9 +11,11 @@ public class SelectionController : MonoBehaviour
     [SerializeField] private string action1;
     [SerializeField] private InputManager playerHandler;
 
-    private readonly float inputZone = 0.04f;
+    private float deadZoneX = 0f;
+    private readonly float deadZoneRight = 0.04f;
+    private float deadZoneLeft = 0.4f;
     private string rightHorizontal = null;
-    private string rightVertical = null;
+    private string horizontal = null;
     private bool inputBool = false;
     private bool isSelecting = false;
     private bool playerSelected = false;
@@ -46,17 +48,18 @@ public class SelectionController : MonoBehaviour
 
     private void Update()
     {
-        if (!hasControllerJoined && Input.GetAxis(action1) == 1) //For PS4, Xbox and Keyboard
+        if (!hasControllerJoined && Input.GetAxis(action1) >= 1 - 0.5f) //For PS4, Xbox and Keyboard
             ControllerJoin();
-        else if (hasControllerJoined && !isSelecting && Input.GetAxis(action1) == 1) //For PS4, Xbox and Keyboard
+        else if (hasControllerJoined && !isSelecting && Input.GetAxis(action1) >= 1 - 0.5f) //For PS4, Xbox and Keyboard
             ControllerSelectPlayer();
         else if (isSelecting && Input.GetAxis(action1) <= 0)
             isSelecting = false;
 
         float m_inputX = Input.GetAxis(rightHorizontal);
-
-        if (hasControllerJoined && !playerSelected && m_inputX != 0)
-            CheckSelection(m_inputX);
+        float m_inputX2 = Input.GetAxis(horizontal);
+        
+        if (hasControllerJoined && !playerSelected && (m_inputX != 0 || m_inputX2 != 0))
+            CheckSelection(m_inputX, m_inputX2);
 
     }
 
@@ -128,14 +131,14 @@ public class SelectionController : MonoBehaviour
     {
         action1 = StringManager.Inputs.Action1 + CONTROLLER_ID;
         rightHorizontal = StringManager.Inputs.RightHorizontal + CONTROLLER_ID;
-        rightVertical = StringManager.Inputs.RightVertical + CONTROLLER_ID;
+        horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
     }
 
     private void MapPs4()
     {
         action1 = StringManager.Inputs.Action1PS4 + CONTROLLER_ID;
         rightHorizontal = StringManager.Inputs.RightHorizontalPS4 + CONTROLLER_ID;
-        rightVertical = StringManager.Inputs.RightVerticalPS4 + CONTROLLER_ID;
+        horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
     }
 
     private void MapSwitch()
@@ -149,25 +152,33 @@ public class SelectionController : MonoBehaviour
         PassControllersToGame.keyBoardOwnedBy = CONTROLLER_ID;
                 
         rightHorizontal = StringManager.Inputs.HorizontalKeyboard;
-        rightVertical = StringManager.Inputs.VerticalKeyboard;
+        horizontal = StringManager.Inputs.HorizontalKeyboard;
         action1 = StringManager.Inputs.Action1Keyboard;
     }
     
-    private void CheckSelection(float _inputX)
+    private void CheckSelection(float _inputXRight, float _inputXLeft)
     {
-        if (_inputX > inputZone || _inputX < -inputZone)
+        if (Mathf.Abs(_inputXLeft) > Mathf.Abs(_inputXRight))
+        {
+            _inputXRight = _inputXLeft;
+            deadZoneX = deadZoneLeft;
+        }
+        else
+            deadZoneX = deadZoneRight;
+
+        if (_inputXRight > deadZoneX || _inputXRight < -deadZoneX)
         {
             if (inputBool)
                 return;
 
-            if (_inputX > inputZone) _inputX = Mathf.CeilToInt(_inputX);
-            else if (_inputX < -inputZone) _inputX = Mathf.FloorToInt(_inputX);
+            if (_inputXRight > deadZoneX) _inputXRight = Mathf.CeilToInt(_inputXRight);
+            else if (_inputXRight < -deadZoneX) _inputXRight = Mathf.FloorToInt(_inputXRight);
 
             inputBool = true;
 
-            if (_inputX > 0)
+            if (_inputXRight > 0)
                 myPlayer.SelectedCharacterSelection.NextCharacter(false);
-            else if (_inputX < 0)
+            else if (_inputXRight < 0)
                 myPlayer.SelectedCharacterSelection.NextCharacter(true);
         }
         else

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/UpdateSelectedCharacters.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/UpdateSelectedCharacters.cs
@@ -4,6 +4,7 @@ using UnityEngine.Events;
 public class UpdateSelectedCharacters : MonoBehaviour
 {
     [SerializeField] private Sprite[] characters = new Sprite[4];
+    [SerializeField] private Sprite[] charactersNotSelected = new Sprite[4];
     [SerializeField] private Sprite[] charactersSelected = new Sprite[4];
     [SerializeField] private Sprite[] charactersChosed = new Sprite[4];
     [SerializeField] private UnityEvent onSpriteChange;
@@ -16,9 +17,20 @@ public class UpdateSelectedCharacters : MonoBehaviour
         characters[(_index + 1) % 4] = charactersSelected[(_index + 1) % 4];
         onSpriteChange.Invoke();
     }
+    
+    public void SetDeselected(int _index)
+    {
+        characters[(_index + 1) % 4] = charactersNotSelected[(_index + 1) % 4];
+        onSpriteChange.Invoke();
+    }
 
     public Sprite GetSelected(int _index)
     {
         return charactersChosed[(_index + 1) % 4];
+    }
+    
+    public Sprite GetDeselected(int _index)
+    {
+        return charactersNotSelected[(_index + 1) % 4];
     }
 }

--- a/FranticFour/Assets/02_Prefabs/Player 1.prefab
+++ b/FranticFour/Assets/02_Prefabs/Player 1.prefab
@@ -697,6 +697,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   animTime: 1.2
   xScaleTo: 3
+  xStandard: 6
 --- !u!1 &6998779927648383170
 GameObject:
   m_ObjectHideFlags: 0
@@ -923,12 +924,8 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 9be433a10d16df74c9100a9551a8264e, type: 3}
   - {fileID: 21300000, guid: b7328bf4b4d8b774eb4f37fb5f0cff15, type: 3}
   - {fileID: 21300000, guid: 0cec3c7c00d7a954d997e57b022f3022, type: 3}
-  charactersSelected:
-  - {fileID: 21300000, guid: 99e97992d205eee4882b2357f36c0f90, type: 3}
-  - {fileID: 21300000, guid: a5dc129d6bc83574f8eeed9e0313b293, type: 3}
-  - {fileID: 21300000, guid: 0cec3c7c00d7a954d997e57b022f3022, type: 3}
-  - {fileID: 21300000, guid: b7328bf4b4d8b774eb4f37fb5f0cff15, type: 3}
   selectedCharacterIndex: 0
+  playersSpriteHandler: {fileID: 0}
 --- !u!1 &8766947298170974516
 GameObject:
   m_ObjectHideFlags: 0
@@ -987,6 +984,3 @@ MonoBehaviour:
   selectedCharacterSelection: {fileID: 3153165024394145032}
   characterSelectionGameObject: {fileID: 8539167374821323862}
   characterMaskCloseSelect: {fileID: 8906902644441261625}
-  characterSelected:
-    m_PersistentCalls:
-      m_Calls: []

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -54,6 +54,22 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
+    m_Name: ButtonBKeyboard
+    descriptiveName: Backspace on keyboard
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: backspace
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
     m_Name: JumpKeyboard
     descriptiveName: 
     descriptiveNegativeName: 
@@ -187,6 +203,38 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: ButtonB0
+    descriptiveName: B-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: ButtonCirclePS40
+    descriptiveName: Circle-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 2
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
@@ -374,6 +422,38 @@ InputManager:
     axis: 2
     joyNum: 2
   - serializedVersion: 3
+    m_Name: ButtonB1
+    descriptiveName: B-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: ButtonCirclePS41
+    descriptiveName: Circle-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 2
+  - serializedVersion: 3
     m_Name: ButtonXPS41
     descriptiveName: X-button on the PS4 controller
     descriptiveNegativeName: 
@@ -550,6 +630,38 @@ InputManager:
     axis: 2
     joyNum: 3
   - serializedVersion: 3
+    m_Name: ButtonB2
+    descriptiveName: B-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 3
+  - serializedVersion: 3
+    m_Name: ButtonCirclePS42
+    descriptiveName: Circle-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 3
+  - serializedVersion: 3
     m_Name: ButtonXPS42
     descriptiveName: X-button on the PS4 controller
     descriptiveNegativeName: 
@@ -715,6 +827,38 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: ButtonB3
+    descriptiveName: B-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: ButtonCirclePS43
+    descriptiveName: Circle-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 2
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -202,7 +202,7 @@ InputManager:
     descriptiveName: X-button on the PS4 controller
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: joystick button 0
+    positiveButton: joystick button 1
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -358,6 +358,38 @@ InputManager:
     axis: 2
     joyNum: 2
   - serializedVersion: 3
+    m_Name: ButtonA1
+    descriptiveName: A-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: ButtonXPS41
+    descriptiveName: X-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 2
+  - serializedVersion: 3
     m_Name: Action1PS41
     descriptiveName: 
     descriptiveNegativeName: 
@@ -502,6 +534,38 @@ InputManager:
     axis: 2
     joyNum: 3
   - serializedVersion: 3
+    m_Name: ButtonA2
+    descriptiveName: A-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 3
+  - serializedVersion: 3
+    m_Name: ButtonXPS42
+    descriptiveName: X-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 3
+  - serializedVersion: 3
     m_Name: Action1PS42
     descriptiveName: 
     descriptiveNegativeName: 
@@ -643,6 +707,38 @@ InputManager:
     snap: 0
     invert: 0
     type: 2
+    axis: 2
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: ButtonA3
+    descriptiveName: A-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: ButtonXPS43
+    descriptiveName: X-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 1
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
     axis: 2
     joyNum: 4
   - serializedVersion: 3

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -14,7 +14,7 @@ InputManager:
     altNegativeButton: a
     altPositiveButton: d
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 0
@@ -30,7 +30,7 @@ InputManager:
     altNegativeButton: s
     altPositiveButton: w
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 0
@@ -62,7 +62,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1.5
-    dead: 0.3
+    dead: 0.005
     sensitivity: 1.1
     snap: 0
     invert: 0
@@ -78,7 +78,7 @@ InputManager:
     altNegativeButton: a
     altPositiveButton: d
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 0
@@ -94,7 +94,7 @@ InputManager:
     altNegativeButton: s
     altPositiveButton: w
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 1
@@ -206,7 +206,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1.5
-    dead: 0.3
+    dead: 0.005
     sensitivity: 1.1
     snap: 0
     invert: 0
@@ -222,7 +222,7 @@ InputManager:
     altNegativeButton: a
     altPositiveButton: d
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 0
@@ -238,7 +238,7 @@ InputManager:
     altNegativeButton: s
     altPositiveButton: w
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 1
@@ -350,7 +350,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1.5
-    dead: 0.3
+    dead: 0.005
     sensitivity: 1.1
     snap: 0
     invert: 0
@@ -366,7 +366,7 @@ InputManager:
     altNegativeButton: a
     altPositiveButton: d
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 0
@@ -382,7 +382,7 @@ InputManager:
     altNegativeButton: s
     altPositiveButton: w
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 1
@@ -494,7 +494,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1.5
-    dead: 0.3
+    dead: 0.005
     sensitivity: 1.1
     snap: 0
     invert: 0
@@ -510,7 +510,7 @@ InputManager:
     altNegativeButton: a
     altPositiveButton: d
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 0
@@ -526,7 +526,7 @@ InputManager:
     altNegativeButton: s
     altPositiveButton: w
     gravity: 3
-    dead: 0.3
+    dead: 0.005
     sensitivity: 3
     snap: 1
     invert: 1
@@ -638,7 +638,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 1.5
-    dead: 0.3
+    dead: 0.005
     sensitivity: 1.1
     snap: 0
     invert: 0

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -110,7 +110,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 0
@@ -126,7 +126,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -142,7 +142,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 0
@@ -158,7 +158,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -179,6 +179,38 @@ InputManager:
     snap: 0
     invert: 0
     type: 2
+    axis: 2
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: ButtonA0
+    descriptiveName: A-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: ButtonXPS40
+    descriptiveName: X-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick button 0
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
     axis: 2
     joyNum: 1
   - serializedVersion: 3
@@ -254,7 +286,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 0
@@ -270,7 +302,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -286,7 +318,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -302,7 +334,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -398,7 +430,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 0
@@ -414,7 +446,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -430,7 +462,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -446,7 +478,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -542,7 +574,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 0
@@ -558,7 +590,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -574,7 +606,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1
@@ -590,7 +622,7 @@ InputManager:
     altNegativeButton: 
     altPositiveButton: 
     gravity: 0
-    dead: 0.02
+    dead: 0.005
     sensitivity: 0.1
     snap: 0
     invert: 1

--- a/FranticFour/ProjectSettings/InputManager.txt
+++ b/FranticFour/ProjectSettings/InputManager.txt
@@ -1,4 +1,0 @@
-Test
-Apa
-Bonkers
-YeeetS


### PR DESCRIPTION
## A global dead-zone rework and changes for the PlayerSelection scene.

### Finished
- [x] Dead-zones tweaked for Player Selection.
- [x] InputManager dead-zone settings changed from 0.3 -> 0.05.
&ensp;_This is necessary to create a more precise and better feeling input from the player to the game._
- [x] Players are now able to switch characters with any of the two sticks. (Keyboard is still the same with 'd' and 'a')
- [x] DeadZones.cs now holds the Dead-zones values that should be used when checking for input.
&ensp;_This will probably need tweaking. If any inputs problems comes up, please contact you local garbageman._
- [x] The 'X' button is added for Dualshock 4.
- [x] The 'A' button is added for Xbox controller.
- [x] The 'X' button is implemented for use with the Dualshock 4.
- [x] The 'A' button is implemented for use with the Xbox controller.
- [x] Able to press X/A to join the character selection screen.
- [x] Able to press X/A to select a character.
- [x] Add 'o' button for Dualshock 4.
- [x] The 'B' for Xbox controller.
- [x] The 'o' button is implemented for use with the Dualshock 4.
- [x] The 'B' button is implemented for use with the Xbox controller.
- [x] Able to press o/B to deselect a chosen character.
- [x] Fix leanscale bug when selecting and deselecting.
<br/>
<br/>
Best regards, The board of OmpaLompa kingdom.
<br/>
<p align="center">
  <img width="300" height="195" src="https://user-images.githubusercontent.com/42805059/100624284-9153eb00-3323-11eb-8038-8a615f98eead.png">
</p>

_Forever grateful, Ompalompa Erste Reich._
<br/>
 