### PR TITLE
Fixed rotation input

### DIFF
--- a/FranticFour/Assets/01_Scripts/Managers/DeadZones.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/DeadZones.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Should be used to check input from "Horizontal" or "Vertical".
     /// </summary>
-    public const float DEADZONE_LEFT = 0.3f;
+    public const float DEADZONE_LEFT = 0.33f;
         
     //right controller stick
     public const float DEADZONE_RIGHT_X = 0.3f;
@@ -14,5 +14,5 @@
     /// <summary>
     /// Should be used to check input from "RightHorizontal" or "RightVertical".
     /// </summary>
-    public const float DEADZONE_RIGHT = 0.3f;
+    public const float DEADZONE_RIGHT = 0.33f;
 }

--- a/FranticFour/Assets/01_Scripts/Player/RotationController.cs
+++ b/FranticFour/Assets/01_Scripts/Player/RotationController.cs
@@ -6,7 +6,11 @@ public class RotationController : MonoBehaviour
     AssignedController controller;
 
     Vector2 dir = new Vector2(0, 0);
-    public Vector2 Dir { get { return dir; } }
+
+    public Vector2 Dir
+    {
+        get { return dir; }
+    }
 
     void Start()
     {
@@ -29,19 +33,27 @@ public class RotationController : MonoBehaviour
 
     private void HandleControllerRotation()
     {
-        float inputX = Input.GetAxis(controller.RightHorizontal);
-        float inputY = Input.GetAxis(controller.RightVertical);
-        if (inputX != 0)
-            dir.x = inputX;
-        if (inputY != 0)
-            dir.y = inputY;
-        objectToRotate.transform.rotation = Quaternion.Euler(new Vector3(0, 0, Mathf.Atan2(-dir.x, dir.y) * Mathf.Rad2Deg));
+        Vector2 inputRight = new Vector2(Input.GetAxis(controller.RightHorizontal), Input.GetAxis(controller.RightVertical));
+        Vector2 inputLeft = new Vector2(Input.GetAxis(controller.Horizontal), Input.GetAxis(controller.Vertical));
+
+        if (inputLeft.magnitude != 0)
+        {
+            Debug.Log(inputRight.magnitude);
+        }
+        
+        if (inputRight.magnitude > DeadZones.DEADZONE_RIGHT)
+            objectToRotate.transform.rotation =
+                Quaternion.Euler(new Vector3(0, 0, Mathf.Atan2(-inputRight.x, inputRight.y) * Mathf.Rad2Deg));
+        else if (inputLeft.magnitude > DeadZones.DEADZONE_LEFT)
+            objectToRotate.transform.rotation =
+                Quaternion.Euler(new Vector3(0, 0, Mathf.Atan2(-inputLeft.x, inputLeft.y) * Mathf.Rad2Deg));
     }
 
     private void HandleMouseRotation()
     {
         var position = Camera.main.WorldToScreenPoint(transform.position);
         dir = Input.mousePosition - position;
-        objectToRotate.transform.rotation = Quaternion.Euler(new Vector3(0, 0, Mathf.Atan2(-dir.x, dir.y) * Mathf.Rad2Deg));
+        objectToRotate.transform.rotation =
+            Quaternion.Euler(new Vector3(0, 0, Mathf.Atan2(-dir.x, dir.y) * Mathf.Rad2Deg));
     }
 }

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -125,9 +125,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 0
     type: 2
@@ -141,9 +141,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -157,9 +157,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 0
     type: 2
@@ -173,9 +173,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -333,9 +333,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 0
     type: 2
@@ -349,9 +349,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -365,9 +365,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -381,9 +381,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -541,9 +541,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 0
     type: 2
@@ -557,9 +557,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -573,9 +573,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -589,9 +589,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -749,9 +749,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 0
     type: 2
@@ -765,9 +765,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -781,9 +781,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2
@@ -797,9 +797,9 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
+    gravity: 3
     dead: 0.005
-    sensitivity: 0.1
+    sensitivity: 3
     snap: 0
     invert: 1
     type: 2


### PR DESCRIPTION
## Description
When roating the controls were snappy and the dead zone was weird. This is now fixed. If no direction input is given from the player the player will be rotated from the left input. Good [link](https://www.gamasutra.com/blogs/JoshSutphin/20130416/190541/Doing_Thumbstick_Dead_Zones_Right.php) to read about input, thanks to @Linus-Jonsson for this.

## DoD
- [x] Fixed controls settings (Set the sensitivity and gravity the same).
- [x] Rotation after movement if direction is not given.
- [x] Made rotation smooth.