### PR TITLE
Laysers fixed

### DIFF
--- a/FranticFour/Assets/02_Prefabs/Player.prefab
+++ b/FranticFour/Assets/02_Prefabs/Player.prefab
@@ -74,7 +74,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 3
   m_Sprite: {fileID: -3597744770341978105, guid: 2c7763adefad10f4f9732ca2b2653deb, type: 3}
   m_Color: {r: 0.9607843, g: 0.634733, b: 0, a: 1}
   m_FlipX: 0
@@ -5233,7 +5233,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 21300000, guid: 1e371181d2108674f80bb87b29946bef, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0


### PR DESCRIPTION
## Description
Fixed layer order for players. There is still a problem that makes the player render in front of a bush. To fix this we would need a longer "bush top" sprite. Also, did not find any problems when play testing __alone__.

## DoD
- [x] Layers set to the correct order
- [x] Fix merge conflict