### PR TITLE
Fixed out of bounds

### DIFF
--- a/FranticFour/ProjectSettings/Physics2DSettings.asset
+++ b/FranticFour/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ff1b35ffff1f35ffff1f35ffffffffffff1f35ffff1f35ffffffffffffffffffff2f35ffff0715fffe5f15ffff3d15ffff1c15ffc80905ffc80405ffc80020ffff7f27ffc80025ffff7f37ffc80000ffff1f34ffff8137ffc800c0ffc800c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ff1b35ffff1f35ffff1f35ffffffffffff1f35ffff1f35ffffffffffffffffffff2f35ffff0715fffe5f15ffff3d15ffff1c15ffc80905ffc80405ffc80060ffff7f27ffc80025ffff7f37ffc80000ffff1f34ffff8137ffc880c0ffc800c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
## Description
Ghosts can't run outside of the map. Ghost can't run outside of the camera bounds.

## DoD
- [x] Ghosts can't run outside of the map
- [x] Ghost no move outside bounds do 

Best regards, The board of OmpaLompa kingdom.
<p align="left">
  <img width="300" height="196" src="https://user-images.githubusercontent.com/42805059/100624284-9153eb00-3323-11eb-8038-8a615f98eead.png">

_Forever grateful, Ompalompa Erste Reich._
<br/>