### PR TITLE
Twin sticks buttons & small fixes/changes

### DIFF
--- a/FranticFour/Assets/01_Scripts/Controlls/AssignedController.cs
+++ b/FranticFour/Assets/01_Scripts/Controlls/AssignedController.cs
@@ -64,12 +64,17 @@ public class AssignedController : MonoBehaviour
         rightVertical = Inputs.RightVertical + playerID;
         rightHorizontal = Inputs.RightHorizontal + playerID;
 
-        action1 = Inputs.Action1 + playerID;
-
-        if (usesTwinSticks)
+        if (!usesTwinSticks)
+        {
+            action1 = ButtonInputs.X_Button + playerID;
             jump = ButtonInputs.A_Button + playerID;
+        }
         else
+        {
+            action1 = Inputs.Action1 + playerID;
             jump = Inputs.Jump + playerID;
+        }
+        
     }
 
     private void SetControllerKeysPS4() //PS4
@@ -80,12 +85,16 @@ public class AssignedController : MonoBehaviour
         rightVertical = Inputs.RightVerticalPS4 + playerID;
         rightHorizontal = Inputs.RightHorizontalPS4 + playerID;
 
-        action1 = Inputs.Action1PS4 + playerID;
-        
-        if (usesTwinSticks)
+        if (!usesTwinSticks)
+        {
+            action1 = ButtonInputs.Square_ButtonPS4 + playerID;
             jump = ButtonInputs.X_ButtonPS4 + playerID;
+        }
         else
+        {
+            action1 = Inputs.Action1PS4 + playerID;
             jump = Inputs.Jump + playerID;
+        }
     }
     
     private void SetControllerKeysSwitch() //Todo Switch

--- a/FranticFour/Assets/01_Scripts/Controlls/AssignedController.cs
+++ b/FranticFour/Assets/01_Scripts/Controlls/AssignedController.cs
@@ -7,6 +7,7 @@ public class AssignedController : MonoBehaviour
     [Header("Player")] [Range(0, 3)]
     [SerializeField] private int playerID;
     [SerializeField] private bool usesMouse;
+    [SerializeField] private bool usesTwinSticks;
 
     public int PlayerID
     {
@@ -22,6 +23,16 @@ public class AssignedController : MonoBehaviour
     {
         get => usesMouse;
         private set => usesMouse = value;
+    }
+    
+    public bool UsesTwinSticks
+    {
+        get => usesTwinSticks;
+        private set { usesTwinSticks = value;
+            if (usesTwinSticks)
+                jump = ButtonInputs.A_Button + playerID;
+            else
+                jump = Inputs.Jump + playerID; }
     }
 
     //Control buttons
@@ -54,7 +65,11 @@ public class AssignedController : MonoBehaviour
         rightHorizontal = Inputs.RightHorizontal + playerID;
 
         action1 = Inputs.Action1 + playerID;
-        jump = Inputs.Jump + playerID;
+
+        if (usesTwinSticks)
+            jump = ButtonInputs.A_Button + playerID;
+        else
+            jump = Inputs.Jump + playerID;
     }
 
     private void SetControllerKeysPS4() //PS4
@@ -66,7 +81,11 @@ public class AssignedController : MonoBehaviour
         rightHorizontal = Inputs.RightHorizontalPS4 + playerID;
 
         action1 = Inputs.Action1PS4 + playerID;
-        jump = Inputs.Jump + playerID;
+        
+        if (usesTwinSticks)
+            jump = ButtonInputs.X_ButtonPS4 + playerID;
+        else
+            jump = Inputs.Jump + playerID;
     }
     
     private void SetControllerKeysSwitch() //Todo Switch

--- a/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
@@ -30,6 +30,7 @@
 
     public struct ButtonInputs
     {
+        // (Xbox/Dualshock)
         // A/X
         public const string A_Button = "ButtonA"; //XBOX
         public const string X_ButtonPS4 = "ButtonXPS4"; //PS4
@@ -39,5 +40,9 @@
         public const string B_Button = "ButtonB"; //XBOX
         public const string Circle_ButtonPS4 = "ButtonCirclePS4"; //PS4
         public const string B_ButtonKeyboard = "ButtonBKeyboard"; //Keyboard
+        
+        // X/Square
+        public const string X_Button = "ButtonX"; //XBOX
+        public const string Square_ButtonPS4 = "ButtonSquarePS4"; //PS4
     }
 }

--- a/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
+++ b/FranticFour/Assets/01_Scripts/Managers/StringManager.cs
@@ -30,10 +30,12 @@
 
     public struct ButtonInputs
     {
+        // A/X
         public const string A_Button = "ButtonA"; //XBOX
         public const string X_ButtonPS4 = "ButtonXPS4"; //PS4
         public const string A_ButtonKeyboard = "JumpKeyboard"; //Keyboard
-
+        
+        // B/Circle
         public const string B_Button = "ButtonB"; //XBOX
         public const string Circle_ButtonPS4 = "ButtonCirclePS4"; //PS4
         public const string B_ButtonKeyboard = "ButtonBKeyboard"; //Keyboard

--- a/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
+++ b/FranticFour/Assets/01_Scripts/PlayerSelectionScene/SelectionController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using static StringManager;
 
 public class SelectionController : MonoBehaviour
 {
@@ -136,11 +137,11 @@ public class SelectionController : MonoBehaviour
         {
                 string controllerName = controllersConnected[CONTROLLER_ID].ToLower();
 
-            if (controllerName.Contains(StringManager.Controllers.Xbox))
+            if (controllerName.Contains(Controllers.Xbox))
                 MapXbox();
-            else if (controllerName.Contains(StringManager.Controllers.PS4))
+            else if (controllerName.Contains(Controllers.PS4))
                 MapPs4();
-            else if (controllerName.Contains(StringManager.Controllers.Switch))
+            else if (controllerName.Contains(Controllers.Switch))
                 MapSwitch();
         }
         else
@@ -160,25 +161,25 @@ public class SelectionController : MonoBehaviour
     private void MapXbox()
     {
         //Buttons Xbox
-        action1 = StringManager.Inputs.Action1 + CONTROLLER_ID;
-        aButton = StringManager.ButtonInputs.A_Button + CONTROLLER_ID;
-        bButton = StringManager.ButtonInputs.B_Button + CONTROLLER_ID;
+        action1 = Inputs.Action1 + CONTROLLER_ID;
+        aButton = ButtonInputs.A_Button + CONTROLLER_ID;
+        bButton = ButtonInputs.B_Button + CONTROLLER_ID;
         
         //Axis Xbox
-        rightHorizontal = StringManager.Inputs.RightHorizontal + CONTROLLER_ID;
-        horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
+        rightHorizontal = Inputs.RightHorizontal + CONTROLLER_ID;
+        horizontal = Inputs.Horizontal + CONTROLLER_ID;
     }
 
     private void MapPs4()
     {
         //Buttons PS4
-        action1 = StringManager.Inputs.Action1PS4 + CONTROLLER_ID;
-        aButton = StringManager.ButtonInputs.X_ButtonPS4 + CONTROLLER_ID;
-        bButton = StringManager.ButtonInputs.Circle_ButtonPS4 + CONTROLLER_ID;
+        action1 = Inputs.Action1PS4 + CONTROLLER_ID;
+        aButton = ButtonInputs.X_ButtonPS4 + CONTROLLER_ID;
+        bButton = ButtonInputs.Circle_ButtonPS4 + CONTROLLER_ID;
         
         //Axis PS4
-        rightHorizontal = StringManager.Inputs.RightHorizontalPS4 + CONTROLLER_ID;
-        horizontal = StringManager.Inputs.Horizontal + CONTROLLER_ID;
+        rightHorizontal = Inputs.RightHorizontalPS4 + CONTROLLER_ID;
+        horizontal = Inputs.Horizontal + CONTROLLER_ID;
     }
 
     private void MapSwitch()
@@ -192,12 +193,12 @@ public class SelectionController : MonoBehaviour
         PassControllersToGame.isKeyboardUsed = true;
         PassControllersToGame.keyBoardOwnedBy = CONTROLLER_ID;
                 
-        rightHorizontal = StringManager.Inputs.HorizontalKeyboard;
-        horizontal = StringManager.Inputs.HorizontalKeyboard;
+        rightHorizontal = Inputs.HorizontalKeyboard;
+        horizontal = Inputs.HorizontalKeyboard;
         
-        action1 = StringManager.Inputs.Action1Keyboard;
-        aButton = StringManager.ButtonInputs.A_ButtonKeyboard;
-        bButton = StringManager.ButtonInputs.B_ButtonKeyboard;
+        action1 = Inputs.Action1Keyboard;
+        aButton = ButtonInputs.A_ButtonKeyboard;
+        bButton = ButtonInputs.B_ButtonKeyboard;
     }
     
     private void CheckSelection(float _inputXRight, float _inputXLeft)

--- a/FranticFour/ProjectSettings/InputManager.asset
+++ b/FranticFour/ProjectSettings/InputManager.asset
@@ -230,11 +230,43 @@ InputManager:
     axis: 2
     joyNum: 1
   - serializedVersion: 3
+    m_Name: ButtonX0
+    descriptiveName: X-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 1 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 1
+  - serializedVersion: 3
     m_Name: ButtonCirclePS40
     descriptiveName: Circle-button on the PS4 controller
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick 1 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: ButtonSquarePS40
+    descriptiveName: Square-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 1 button 0
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
@@ -438,11 +470,43 @@ InputManager:
     axis: 2
     joyNum: 2
   - serializedVersion: 3
+    m_Name: ButtonX1
+    descriptiveName: X-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 2 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 2
+  - serializedVersion: 3
     m_Name: ButtonCirclePS41
     descriptiveName: Circle-button on the PS4 controller
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick 2 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: ButtonSquarePS41
+    descriptiveName: Square-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 2 button 0
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
@@ -646,11 +710,43 @@ InputManager:
     axis: 2
     joyNum: 3
   - serializedVersion: 3
+    m_Name: ButtonX2
+    descriptiveName: X-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 3 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 3
+  - serializedVersion: 3
     m_Name: ButtonCirclePS42
     descriptiveName: Circle-button on the PS4 controller
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick 3 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 3
+  - serializedVersion: 3
+    m_Name: ButtonSquarePS42
+    descriptiveName: Square-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 3 button 0
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3
@@ -854,11 +950,43 @@ InputManager:
     axis: 2
     joyNum: 4
   - serializedVersion: 3
+    m_Name: ButtonX3
+    descriptiveName: X-button on the Xbox controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 4 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 4
+  - serializedVersion: 3
     m_Name: ButtonCirclePS43
     descriptiveName: Circle-button on the PS4 controller
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick 4 button 2
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 2
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: ButtonSquarePS43
+    descriptiveName: Square-button on the PS4 controller
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 4 button 0
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3

--- a/FranticFour/ProjectSettings/Physics2DSettings.asset
+++ b/FranticFour/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ff1b35ffff1f35ffff1f35ffffffffffff1f35ffff1f35ffffffffffffffffffff2f35ffff0715fffe5f15ffff3d15ffff1c15ffc80925ffc80405ffc80060ffff7f27ffc80025ffff7f37ffc80000ffff1f34ffffa137ffc880c0ffc800c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ff1b35ffff1f35ffff1f35ffffffffffff1f35ffff1f35ffffffffffffffffffff2f35ffff0715fffe5f15ffff3d15ffff1c15ffc80905ffc80405ffc80060ffff7f27ffc80025ffff7f37ffc80000ffff1f34ffff8137ffc880c0ffc800c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
## Description
The players should be able to choose between using twin-stick controller layout or a non twin-stick layout. Without twin-sticks the player will jump with X/A and throw traps/push with Square/X (Dualshock/Xbox). There is a bug that makes the players unable to jump over a trap. Out of bounds collision disappeared again so it is now added back again.

**Twin-sticks is finished BUT the players will need a way to choose between the two controller maps**

## DoD
- [x] Twin-stick
  - [x] Jump with X/A
  - [x] Throw/push with Square/X
- [x] **Test with Xbox and Dualshock**
- [x] Traps collision fix
- [x] Add ghost bounds... Again...