### PR TITLE
Tweaks and fixes after latest play test

### DIFF
--- a/FranticFour/Assets/01_Scripts/Controlls/TrapController.cs
+++ b/FranticFour/Assets/01_Scripts/Controlls/TrapController.cs
@@ -3,6 +3,11 @@ using UnityEngine;
 
 public class TrapController : MonoBehaviour
 {
+    [Header("Spike trap")]
+    [SerializeField] private bool isSpikeTrap =  false;
+    [SerializeField] private PolygonCollider2D spikeCollider2D;
+    [SerializeField] private float afterAnimDelay = 0.5f;
+    
     [Header("Movement Configuration")]
     [Tooltip("The points that the trap will move inbetween")]
     [SerializeField] Transform[] patrolPoints = new Transform[0];
@@ -40,6 +45,9 @@ public class TrapController : MonoBehaviour
         rb2d = GetComponent<Rigidbody2D>();
         animator = GetComponent<Animator>();
         StartTrap();
+
+        if (isSpikeTrap)
+            spikeCollider2D = GetComponent<PolygonCollider2D>();
     }
     private void StartTrap()
     {
@@ -115,13 +123,17 @@ public class TrapController : MonoBehaviour
     IEnumerator ActivateTrap()
     {
         animator.SetTrigger("On");
+        if (isSpikeTrap)
+            StartCoroutine(ActivateSpikeTrap());
         yield return new WaitForSeconds(Random.Range(activationTimer.x, activationTimer.y));
         StartCoroutine(DeactivateTrap());
     }
     IEnumerator DeactivateTrap()
     {
-        animator.SetTrigger("Off");      
-        yield return new WaitForSeconds(Random.Range(deactivationTimer.x, deactivationTimer.y));
+        animator.SetTrigger("Off");
+        if (isSpikeTrap)
+            StartCoroutine(DeActivateSpikeTrap());
+            yield return new WaitForSeconds(Random.Range(deactivationTimer.x, deactivationTimer.y));
         StartCoroutine(ActivateTrap());
     }
 
@@ -134,4 +146,20 @@ public class TrapController : MonoBehaviour
     {
         GetComponent<AudioSource>().Stop();
     }
+
+    private IEnumerator DeActivateSpikeTrap()
+    {
+        if (spikeCollider2D == null)
+            yield return null;
+        spikeCollider2D.enabled = false;
+    }
+    
+    private IEnumerator ActivateSpikeTrap()
+    {
+        if (spikeCollider2D == null)
+            yield return null;
+        yield return new WaitForSeconds(afterAnimDelay);
+        spikeCollider2D.enabled = true;
+    }
+    
 }

--- a/FranticFour/Assets/02_Prefabs/Garden/Props/bänk2.prefab
+++ b/FranticFour/Assets/02_Prefabs/Garden/Props/bänk2.prefab
@@ -92,8 +92,8 @@ GameObject:
   m_Component:
   - component: {fileID: 4849128452116090964}
   - component: {fileID: 4849128452116090971}
-  - component: {fileID: 3625633598689385456}
   - component: {fileID: 3022263721312305232}
+  - component: {fileID: 1672404385}
   m_Layer: 0
   m_Name: "b\xE4nk2"
   m_TagString: Untagged
@@ -167,32 +167,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &3625633598689385456
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4849128452116090965}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.03528738, y: -0.14115381}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.96, y: 3.62}
-    newSize: {x: 2.56, y: 3.81}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.79559803, y: 2.0455942}
-  m_EdgeRadius: 0
 --- !u!50 &3022263721312305232
 Rigidbody2D:
   serializedVersion: 4
@@ -214,3 +188,19 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!70 &1672404385
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4849128452116090965}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.14, y: -0.09}
+  m_Size: {x: 0.85, y: 2.26}
+  m_Direction: 0

--- a/FranticFour/Assets/02_Prefabs/Traps/DeathPlant.prefab
+++ b/FranticFour/Assets/02_Prefabs/Traps/DeathPlant.prefab
@@ -10,8 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 574438568596135536}
   - component: {fileID: 59459186310562235}
-  - component: {fileID: 704476613446070611}
   - component: {fileID: 3027241566193797330}
+  - component: {fileID: 2271612955785064773}
   - component: {fileID: 21342223172142554}
   m_Layer: 10
   m_Name: DeathPlant
@@ -86,32 +86,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &704476613446070611
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 42031124629323116}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -0.37884855, y: -1.2117178}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 6.4, y: 4.8}
-    newSize: {x: 6.4, y: 4.8}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 2.119669, y: 1.6955028}
-  m_EdgeRadius: 0
 --- !u!50 &3027241566193797330
 Rigidbody2D:
   serializedVersion: 4
@@ -133,6 +107,45 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!60 &2271612955785064773
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 42031124629323116}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 6.4, y: 4.8}
+    newSize: {x: 6.4, y: 4.8}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -1.3296599, y: -0.7719811}
+      - {x: -1.4862021, y: -1.0792654}
+      - {x: -0.92305505, y: -1.4012561}
+      - {x: -0.8648598, y: -1.752056}
+      - {x: -0.9952983, y: -1.9318444}
+      - {x: -0.62953275, y: -2.2429905}
+      - {x: -0.09224324, y: -2.2393458}
+      - {x: 0.081061855, y: -1.8695542}
+      - {x: 0.23005506, y: -1.5319275}
+      - {x: 0.7376429, y: -1.2960455}
+      - {x: 0.8061021, y: -1.0139095}
+      - {x: 0.44570124, y: -0.57766616}
+      - {x: -0.08352958, y: -0.39385742}
+      - {x: -0.71616864, y: -0.44738275}
 --- !u!95 &21342223172142554
 Animator:
   serializedVersion: 3

--- a/FranticFour/Assets/02_Prefabs/Traps/FireTrap.prefab
+++ b/FranticFour/Assets/02_Prefabs/Traps/FireTrap.prefab
@@ -175,8 +175,8 @@ GameObject:
   - component: {fileID: 8086356271132997250}
   - component: {fileID: 8086356271132997251}
   - component: {fileID: 8086356270547099848}
-  - component: {fileID: 2465013434675702302}
   - component: {fileID: 7287188729612870262}
+  - component: {fileID: 5214543388793814622}
   - component: {fileID: 3295371257700270576}
   m_Layer: 10
   m_Name: FireTrap
@@ -242,32 +242,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!61 &2465013434675702302
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8086356271132997248}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -0.22024155, y: -0.064777374}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 4.8866386, y: 0.481781}
-  m_EdgeRadius: 0
 --- !u!114 &7287188729612870262
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,6 +264,46 @@ MonoBehaviour:
   timed: 1
   rotating: 0
   startOn: 1
+--- !u!60 &5214543388793814622
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8086356271132997248}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.46433374, y: 0.47011325}
+      - {x: -0.1714994, y: 0.24719763}
+      - {x: -0.94387794, y: 0.02698262}
+      - {x: -2.7428386, y: -0.0078228265}
+      - {x: -2.7385569, y: -0.10816692}
+      - {x: -2.0026338, y: -0.10411062}
+      - {x: -1.4700222, y: -0.08326401}
+      - {x: -0.80945146, y: -0.4553608}
+      - {x: 0.12783536, y: -0.8254055}
+      - {x: 0.8336095, y: -0.9947505}
+      - {x: 1.7964503, y: -0.8329665}
+      - {x: 2.177217, y: -0.46842682}
+      - {x: 2.1927216, y: -0.060913265}
+      - {x: 1.8382185, y: 0.49957502}
+      - {x: 1.6448257, y: 0.6094684}
 --- !u!82 &3295371257700270576
 AudioSource:
   m_ObjectHideFlags: 0

--- a/FranticFour/Assets/02_Prefabs/Traps/Sawblade.prefab
+++ b/FranticFour/Assets/02_Prefabs/Traps/Sawblade.prefab
@@ -238,10 +238,10 @@ GameObject:
   m_Component:
   - component: {fileID: 4321901722228990947}
   - component: {fileID: 7409600759975392460}
-  - component: {fileID: 8382559940497253827}
   - component: {fileID: 109710980003920614}
   - component: {fileID: 5025744347374280338}
   - component: {fileID: 2379325147797976316}
+  - component: {fileID: 8688732517708834511}
   m_Layer: 13
   m_Name: Sawblade
   m_TagString: Saw
@@ -289,32 +289,6 @@ MonoBehaviour:
   timed: 0
   rotating: 0
   startOn: 0
---- !u!61 &8382559940497253827
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5642508773787456886}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.015528321, y: -0.39065346}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 2.56, y: 1.92}
-    newSize: {x: 6.4, y: 4.8}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1.5002208, y: 0.582421}
-  m_EdgeRadius: 0
 --- !u!50 &109710980003920614
 Rigidbody2D:
   serializedVersion: 4
@@ -451,6 +425,38 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!60 &8688732517708834511
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5642508773787456886}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -0.007849406, y: -0.4286306}
+      - {x: -0.574275, y: -0.5544412}
+      - {x: -0.82263964, y: -0.74459785}
+      - {x: -1.0823112, y: -1.0916035}
+      - {x: 1.1608074, y: -1.0916033}
+      - {x: 0.8070409, y: -0.6918364}
+      - {x: 0.40943277, y: -0.4837945}
 --- !u!1 &6778727438045481281
 GameObject:
   m_ObjectHideFlags: 0

--- a/FranticFour/Assets/02_Prefabs/Traps/SpikeTrap.prefab
+++ b/FranticFour/Assets/02_Prefabs/Traps/SpikeTrap.prefab
@@ -11,8 +11,8 @@ GameObject:
   - component: {fileID: 2256305005253885881}
   - component: {fileID: 1463796915710528557}
   - component: {fileID: 2826172928157078116}
-  - component: {fileID: -2768483631063642237}
   - component: {fileID: 7291022454944819249}
+  - component: {fileID: -6394585831151223910}
   - component: {fileID: 8454379172232270182}
   m_Layer: 13
   m_Name: SpikeTrap
@@ -106,32 +106,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!61 &-2768483631063642237
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1969485075884854441}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -0.0031795502, y: 0.029076815}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 3.2, y: 2.4}
-    newSize: {x: 6.4, y: 4.8}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1.6758008, y: 1.2685709}
-  m_EdgeRadius: 0
 --- !u!50 &7291022454944819249
 Rigidbody2D:
   serializedVersion: 4
@@ -153,6 +127,37 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!60 &-6394585831151223910
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969485075884854441}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 3.2, y: 2.4}
+    newSize: {x: 6.4, y: 4.8}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.20531608, y: 0.6000266}
+      - {x: 0.49941567, y: 0.45463896}
+      - {x: 0.8933617, y: -0.70126927}
+      - {x: -0.9473053, y: -0.6683765}
+      - {x: -0.8052094, y: -0.29471734}
+      - {x: -0.4262875, y: 0.6052225}
 --- !u!114 &8454379172232270182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -165,6 +170,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70472ff33ed73364682a786b070c29da, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isSpikeTrap: 1
+  spikeCollider2D: {fileID: 0}
+  afterAnimDelay: 0.5
   patrolPoints: []
   movementSpeed: 5
   rotationSpeed: 10

--- a/FranticFour/Assets/02_Prefabs/Traps/Spinning trap.prefab
+++ b/FranticFour/Assets/02_Prefabs/Traps/Spinning trap.prefab
@@ -228,8 +228,8 @@ CapsuleCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.16303466, y: 0.2861374}
-  m_Size: {x: 3.522756, y: 1.1244107}
+  m_Offset: {x: -0.16303466, y: 0.31}
+  m_Size: {x: 3.25, y: 0.9}
   m_Direction: 1
 --- !u!82 &4726498448917023003
 AudioSource:

--- a/FranticFour/Assets/07_Materials/Player 4.mat
+++ b/FranticFour/Assets/07_Materials/Player 4.mat
@@ -79,7 +79,7 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}

--- a/FranticFour/Assets/07_Materials/Player 4.mat
+++ b/FranticFour/Assets/07_Materials/Player 4.mat
@@ -79,7 +79,7 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 0.5019608}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}


### PR DESCRIPTION
## Description
Players can escape at the left top of the map. Colliders on some traps feel a bit off. Players can get stuck at a bench at the far left on the map and after a game is finished, the main menu button does not work. The indications for 16:9 is still on the map in 3 corners.

## DoD
- [x] Main menu button
- [x] Block of map
- [x] Bench collider
- [x] Traps colliders
- [x] Remove 16:9 indications
- [x] **Test changes AND game**

Best regards, The board of OmpaLompa kingdom.
<p align="left">
  <img width="300" height="196" src="https://user-images.githubusercontent.com/42805059/100624284-9153eb00-3323-11eb-8038-8a615f98eead.png">

_Forever grateful, Ompalompa Erste Reich._
<br/>